### PR TITLE
Add notification UserInfo key contants

### DIFF
--- a/Constants.h
+++ b/Constants.h
@@ -20,6 +20,17 @@ extern NSString *kMRMediaRemoteNowPlayingInfoElapsedTime;
 extern NSString *kMRMediaRemoteNowPlayingInfoTimestamp;
 extern NSString *kMRMediaRemoteNowPlayingInfoClientPropertiesData;
 
+extern NSString *kMRActiveNowPlayingPlayerPathUserInfoKey;
+extern NSString *kMRMediaRemoteNowPlayingApplicationDisplayNameUserInfoKey;
 extern NSString *kMRMediaRemoteNowPlayingApplicationIsPlayingUserInfoKey;
+extern NSString *kMRMediaRemoteNowPlayingApplicationIsPlayingUserInfoKey;
+extern NSString *kMRMediaRemoteNowPlayingApplicationPIDUserInfoKey;
+extern NSString *kMRMediaRemoteOriginUserInfoKey;
+extern NSString *kMRMediaRemotePlaybackStateUserInfoKey;
+extern NSString *kMRMediaRemoteUpdatedContentItemsUserInfoKey;
+extern NSString *kMRNowPlayingClientUserInfoKey;
+extern NSString *kMRNowPlayingPlayerPathUserInfoKey;
+extern NSString *kMRNowPlayingPlayerUserInfoKey;
+extern NSString *kMROriginActiveNowPlayingPlayerPathUserInfoKey;
 
 #endif /* PrivateMediaRemote_Constants_h */


### PR DESCRIPTION
Notifications can return info about the running app such as name, PID,
and other useful info.